### PR TITLE
Bug fix: stdout summary fix for values ending in 0.

### DIFF
--- a/test_harness/src/main.cpp
+++ b/test_harness/src/main.cpp
@@ -213,7 +213,8 @@ std::string toDoubleVariableFrac(double x, int up_to_digits_after_dot)
         up_to_digits_after_dot = 0;
     ss << std::fixed << std::setprecision(up_to_digits_after_dot) << x;
     retval = ss.str();
-    retval.erase(retval.find_last_not_of(".0") + 1);
+    retval.erase(retval.find_last_not_of("0") + 1);
+    retval.erase(retval.find_last_not_of(".") + 1);
     return retval;
 }
 


### PR DESCRIPTION
## Proposed changes

Fixes a bug that would cause the removal of trailing zeroes in the summary to standard output for values that end in zero before the decimal point: i.e. 80.0 was getting truncated to 8 instead of 80.

## Types of changes

What types of changes does your code introduce to the HEBench Frontend?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hebench/frontend/blob/main/CONTRIBUTING.md) doc
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a
