### PR TITLE
Bug fix: corrected number of input samples added in report compiler.

### DIFF
--- a/report_gen/report_compiler_lib/src/hebench_report_stats.cpp
+++ b/report_gen/report_compiler_lib/src/hebench_report_stats.cpp
@@ -247,8 +247,11 @@ ReportStats::ReportStats(const cpp::TimingReport &report)
         } // end if
         if (b_added)
             event_ids.push_back(event.event_type_id);
-        cpu_events[event.event_type_id].push_back(cpu_time);
-        wall_events[event.event_type_id].push_back(wall_time);
+        for (std::uint64_t i = 0; i < event.input_sample_count; ++i)
+        {
+            cpu_events[event.event_type_id].push_back(cpu_time);
+            wall_events[event.event_type_id].push_back(wall_time);
+        } // end for
     } // end for
 
     // sort by event ID


### PR DESCRIPTION
## Proposed changes

- Report compiler was adding a single input sample to the statistics
regardless of whether the event measured was for a single input sample
or multiple (offline mode events).
This would cause that the total wall time and number of samples were
smaller than the real value. The percentile calculations would be skewed.
Samples per second and average time per sample were not affected in general.

Fixed: report compiler now adds the correct number of input samples per event.

## Types of changes

What types of changes does your code introduce to the HEBench Frontend?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hebench/frontend/blob/main/CONTRIBUTING.md) doc
- [ ] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

n/a