### PR TITLE
Modified default offline batch sizes for some operations.

### DIFF
--- a/docsrc/categories/cat_latency.md
+++ b/docsrc/categories/cat_latency.md
@@ -15,11 +15,13 @@ hebench:APIBridge::Category::Latency
 
 ## Category Parameters
 
-All categories support `std::uint64_t min_test_time_ms` to specify the minimum time, in milliseconds, to run the test.
+- `std::uint64_t min_test_time_ms`: supported by all categories.
+  Specifies the minimum time, in milliseconds, to run the test.
 
-Latency category supports `std::uint64_t warmup_iterations_count` which specifies the number of warmup iterations to perform before running the actual test.
+- `std::uint64_t warmup_iterations_count`:
+  Specifies the number of warmup iterations to perform before running the actual test.
 
-See `hebench::APIBridge::CategoryParams` for more information. Note that setting fields of `CategoryParams` to `0` or `null` values (as corresponding to the data types) will allow Test Harness users to configure these from [benchmark configuration files](@ref config_file_reference). Otherwise, configuration files values will be overridden by actual values hard set by the backend in this structure.
+Note that a backend implementation that sets any field in `CategoryParams` to `0` or `null` values (as corresponding to the field data type) is indicating that it accepts any valid value in the supported range for said field (according to the valid ranges as specified in the documentation for each field). In this case, these values are user-configurable using Test Harness features such as [benchmark configuration files](@ref config_file_reference).
 
 ## Description
 
@@ -32,4 +34,3 @@ During latency test, Test Harness passes a single input sample to the backend. W
 To correctly measure latency, the implementation of the backend `hebench::APIBridge::operate()` function should not cache results of previous calls, intermediate, final, or any other kind. This is, results must be computed every time, regardless of whether the input sample are the same as inputs from previous calls. The backend implementation must make sure that the operation actually starts running when the `operate()` function is called, not when the `hebench::APIBridge::load()` function completes. Function `hebench::APIBridge::store()` is provided to retrieve the results of the operation; however, the backend implementation must also ensure that `operate()` does not return until the operation completes and results are ready to be retrieved, not before. For example, if the operation will execute asynchronously, it should start only when `operate()` function is called, and the implementation of `operate()` should block until the asynchronous operation completes.
 
 If the implementation requires warm up iterations, it can request so via benchmark configuration file, or enforce it with the `warmup_iterations_count` field from `hebench::APIBridge::CategoryParams` when filling out the `hebench::APIBridge::BenchmarkDescriptor` structure in the backend. Warmup iterations are calls to `hebench::APIBridge::operate()` exactly as if they were being tested, but they do not affect the measured results. Note that Test Harness still measures the time for the warmup; it is just reported in its own entry in the benchmark report.
-

--- a/docsrc/categories/cat_offline.md
+++ b/docsrc/categories/cat_offline.md
@@ -15,11 +15,13 @@ hebench:APIBridge::Category::Offline
 
 ## Category Parameters
 
-All categories support `std::uint64_t min_test_time_ms` to specify the minimum time, in milliseconds, to run the test.
+- `std::uint64_t min_test_time_ms`: supported by all categories.
+  Specifies the minimum time, in milliseconds, to run the test.
 
-Offline category supports `std::uint64_t data_count[HEBENCH_MAX_OP_PARAMS]` which specifies a hard value for the number of data samples for each input parameter to the workload operation.
+- `std::uint64_t data_count[HEBENCH_MAX_OP_PARAMS]`
+  Specifies a hard value for the number of data samples for each input parameter to the workload operation.
 
-See `hebench::APIBridge::CategoryParams` for more information. Note that setting fields of `CategoryParams` to `0` or `null` values (as corresponding to the data types) will allow Test Harness users to configure these from [benchmark configuration files](@ref config_file_reference). Otherwise, configuration files values will be overridden by actual values hard set by the backend in this structure.
+Note that a backend implementation that sets any field in `CategoryParams` to `0` or `null` values (as corresponding to the field data type) is indicating that it accepts any valid value in the supported range for said field (according to the valid ranges as specified in the documentation for each field). In this case, these values are user-configurable using Test Harness features such as [benchmark configuration files](@ref config_file_reference).
 
 ## Description
 

--- a/docsrc/tests/dot_product.md
+++ b/docsrc/tests/dot_product.md
@@ -83,12 +83,12 @@ See @ref category_latency .
 #### Offline
 See @ref category_offline .
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but sample size of `0` is specified by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|
-| `0` | `1` | none |`100` | 
-| `1` | `1` | none |`100` | 
+| `0` | `1` | none |`5` | 
+| `1` | `1` | none |`5` | 
 
 ## Data Type
 

--- a/docsrc/tests/elementwise_add.md
+++ b/docsrc/tests/elementwise_add.md
@@ -82,12 +82,12 @@ See @ref category_latency .
 #### Offline
 See @ref category_offline .
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but sample size of `0` is specified by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|
-| `0` | `1` | none |`100` | 
-| `1` | `1` | none |`100` | 
+| `0` | `1` | none |`5` | 
+| `1` | `1` | none |`5` | 
 
 ## Data Type
 

--- a/docsrc/tests/elementwise_mult.md
+++ b/docsrc/tests/elementwise_mult.md
@@ -74,12 +74,12 @@ See @ref category_latency .
 #### Offline
 See @ref category_offline .
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but sample size of `0` is specified by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|
-| `0` | `1` | none |`100` | 
-| `1` | `1` | none |`100` | 
+| `0` | `1` | none |`5` | 
+| `1` | `1` | none |`5` | 
 
 ## Data Type
 

--- a/docsrc/tests/generic.md
+++ b/docsrc/tests/generic.md
@@ -93,7 +93,7 @@ See @ref category_latency .
 #### Offline
 See @ref category_offline .
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but no sample size or `0` is specified in the hierarchy by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|

--- a/docsrc/tests/logistic_regression.md
+++ b/docsrc/tests/logistic_regression.md
@@ -118,7 +118,7 @@ See @ref category_latency .
 #### Offline
 See @ref category_offline .
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but sample size of `0` is specified by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|

--- a/docsrc/tests/matrix_multiplication.md
+++ b/docsrc/tests/matrix_multiplication.md
@@ -86,7 +86,7 @@ See @ref category_latency .
 #### Offline
 See @ref category_offline .
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but sample size of `0` is specified by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|

--- a/docsrc/tests/simple_set_intersection.md
+++ b/docsrc/tests/simple_set_intersection.md
@@ -88,12 +88,12 @@ See `hebench::APIBridge::CategoryParams::latency`.
 #### Offline
 See `hebench::APIBridge::CategoryParams::offline`.
 
-Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used for elements that take any sample size, but sample size of `0` is specified by Test Harness.
+Value ranges for elements in `CategoryParams::offline::data_count`. Default value is used when the backend implementation sets the `data_count` for the corresponding operand to `0`, but user specified `0` or no value at run-time.
 
 | Parameter | Lower bound | Upper bound | Default |
 |-|-|-|-|
-| `0` | `1` | none |`100` | 
-| `1` | `1` | none |`100` | 
+| `0` | `1` | none |`5` | 
+| `1` | `1` | none |`5` | 
 
 ## Data Type
 

--- a/test_harness/benchmarks/DotProduct/offline/include/hebench_dotproduct_o.h
+++ b/test_harness/benchmarks/DotProduct/offline/include/hebench_dotproduct_o.h
@@ -27,8 +27,10 @@ public:
 private:
     IL_DECLARE_CLASS_NAME(DotProduct::Offline::BenchmarkDescriptor)
 public:
-    static constexpr std::uint32_t BenchmarkID      = 701;
-    static constexpr std::uint64_t DefaultBatchSize = 100; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 701;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 5;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/DotProduct/offline/src/hebench_dotproduct_o.cpp
+++ b/test_harness/benchmarks/DotProduct/offline/src/hebench_dotproduct_o.cpp
@@ -52,7 +52,7 @@ void BenchmarkDescriptor::completeWorkloadDescription(WorkloadDescriptionOutput 
 {
     // finish describing workload
     assert(OpParameterCount == 2);
-    assert(DefaultBatchSize == 100);
+    assert(DefaultBatchSize == 5);
 
     BenchmarkDescriptorCategory::completeWorkloadDescription(output, engine, backend_desc, config);
 

--- a/test_harness/benchmarks/EltwiseAdd/offline/include/hebench_eltwiseadd_o.h
+++ b/test_harness/benchmarks/EltwiseAdd/offline/include/hebench_eltwiseadd_o.h
@@ -27,8 +27,10 @@ public:
 private:
     IL_DECLARE_CLASS_NAME(EltwiseAdd::Offline::BenchmarkDescriptor)
 public:
-    static constexpr std::uint32_t BenchmarkID      = 401;
-    static constexpr std::uint64_t DefaultBatchSize = 100; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 401;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 5;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/EltwiseAdd/offline/src/hebench_eltwiseadd_o.cpp
+++ b/test_harness/benchmarks/EltwiseAdd/offline/src/hebench_eltwiseadd_o.cpp
@@ -52,7 +52,7 @@ void BenchmarkDescriptor::completeWorkloadDescription(WorkloadDescriptionOutput 
 {
     // finish describing workload
     assert(OpParameterCount == 2);
-    assert(DefaultBatchSize == 100);
+    assert(DefaultBatchSize == 5);
 
     BenchmarkDescriptorCategory::completeWorkloadDescription(output, engine, backend_desc, config);
 

--- a/test_harness/benchmarks/EltwiseMult/offline/include/hebench_eltwisemult_o.h
+++ b/test_harness/benchmarks/EltwiseMult/offline/include/hebench_eltwisemult_o.h
@@ -27,8 +27,10 @@ public:
 private:
     IL_DECLARE_CLASS_NAME(EltwiseMult::Offline::BenchmarkDescriptor)
 public:
-    static constexpr std::uint32_t BenchmarkID      = 601;
-    static constexpr std::uint64_t DefaultBatchSize = 100; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 601;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 5;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/EltwiseMult/offline/src/hebench_eltwisemult_o.cpp
+++ b/test_harness/benchmarks/EltwiseMult/offline/src/hebench_eltwisemult_o.cpp
@@ -52,7 +52,7 @@ void BenchmarkDescriptor::completeWorkloadDescription(WorkloadDescriptionOutput 
 {
     // finish describing workload
     assert(OpParameterCount == 2);
-    assert(DefaultBatchSize == 100);
+    assert(DefaultBatchSize == 5);
 
     BenchmarkDescriptorCategory::completeWorkloadDescription(output, engine, backend_desc, config);
 

--- a/test_harness/benchmarks/Generic/offline/include/hebench_genericwl_o.h
+++ b/test_harness/benchmarks/Generic/offline/include/hebench_genericwl_o.h
@@ -27,8 +27,10 @@ public:
 private:
     IL_DECLARE_CLASS_NAME(GenericWL::Offline::BenchmarkDescriptor)
 public:
-    static constexpr std::uint32_t BenchmarkID      = 1101;
-    static constexpr std::uint64_t DefaultBatchSize = 1; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 1101;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 1;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/LogisticRegression/offline/include/hebench_logreg_o.h
+++ b/test_harness/benchmarks/LogisticRegression/offline/include/hebench_logreg_o.h
@@ -27,8 +27,10 @@ public:
 private:
     IL_DECLARE_CLASS_NAME(LogisticRegression::Offline::BenchmarkDescriptor)
 public:
-    static constexpr std::uint32_t BenchmarkID      = 901;
-    static constexpr std::uint64_t DefaultBatchSize = 100; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 901;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 100;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/MatrixMultiply/offline/include/hebench_matmult_o.h
+++ b/test_harness/benchmarks/MatrixMultiply/offline/include/hebench_matmult_o.h
@@ -27,8 +27,10 @@ public:
 private:
     IL_DECLARE_CLASS_NAME(MatrixMultiply::Latency::BenchmarkDescriptor)
 public:
-    static constexpr std::uint32_t BenchmarkID      = 201;
-    static constexpr std::uint64_t DefaultBatchSize = 100; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 201;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 100;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/SimpleSetIntersection/offline/include/hebench_simple_set_intersection_o.h
+++ b/test_harness/benchmarks/SimpleSetIntersection/offline/include/hebench_simple_set_intersection_o.h
@@ -28,8 +28,10 @@ private:
     IL_DECLARE_CLASS_NAME(SimpleSetIntersection::Offline::BenchmarkDescriptor)
 public:
     // TODO: Ask for ID selection
-    static constexpr std::uint32_t BenchmarkID      = 1301;
-    static constexpr std::uint64_t DefaultBatchSize = 1; // default number of elements for a parameter
+    static constexpr std::uint32_t BenchmarkID = 1301;
+    // default number of samples for an operand
+    // (based on docs definition of the workload operation)
+    static constexpr std::uint64_t DefaultBatchSize = 5;
 
 public:
     BenchmarkDescriptor()           = default;

--- a/test_harness/benchmarks/SimpleSetIntersection/offline/src/hebench_simple_set_intersection_o.cpp
+++ b/test_harness/benchmarks/SimpleSetIntersection/offline/src/hebench_simple_set_intersection_o.cpp
@@ -52,7 +52,7 @@ void BenchmarkDescriptor::completeWorkloadDescription(WorkloadDescriptionOutput 
 {
     // finish describing workload
     assert(OpParameterCount == 2);
-    assert(DefaultBatchSize == 1);
+    assert(DefaultBatchSize == 5);
 
     BenchmarkDescriptorCategory::completeWorkloadDescription(output, engine, backend_desc, config);
 

--- a/test_harness/benchmarks/SimpleSetIntersection/src/hebench_simple_set_intersection.cpp
+++ b/test_harness/benchmarks/SimpleSetIntersection/src/hebench_simple_set_intersection.cpp
@@ -89,6 +89,7 @@ void BenchmarkDescriptorCategory::completeWorkloadDescription(WorkloadDescriptio
        << "k  -> " << sets_size[2];
 
     output.workload_name          = ss.str();
+    output.workload_base_name     = BaseWorkloadName;
     output.operation_params_count = BenchmarkDescriptorCategory::OpParameterCount;
 }
 


### PR DESCRIPTION
## Proposed changes

- Modified default batch sizes for dot product and elt wise operations from 100 to 5 per operand to reduce compute times in CI tests and default runs.

- Updated docs to reflect the change in default sizes.

- Updated wording of docs to make clear when are the default and configurable values used.

- Fixed a bug where simple set intersection name was not being output to report file name due to incorrectly setting the base workload name in the benchmark description.

## Types of changes

What types of changes does your code introduce to the HEBench Frontend?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hebench/frontend/blob/main/CONTRIBUTING.md) doc
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a